### PR TITLE
Fix final layer of the SSL sock leak.

### DIFF
--- a/lib/Perlbal/SocketSSL.pm
+++ b/lib/Perlbal/SocketSSL.pm
@@ -56,7 +56,7 @@ Perlbal::Socket->set_socket_idle_handler('Perlbal::SocketSSL' => sub {
     return unless $max_age;
 
     # Attributes are in another class, don't violate object boundaries.
-    $v->close("perlbal_timeout")
+    $v->{sock}->close(SSL_no_shutdown => 1, SSL_ctx_free => 1)
         if $v->{alive_time} < $Perlbal::tick_time - $max_age;
 });
 


### PR DESCRIPTION
Apparently you can't just call ->close on an IO::Socket::SSL wrapping Danga::Socket, because the SSL cleanup may not happen.

So instead call ->close on the inner IO::Socket::SSL object with the right flags to shut down the socket.Perlbal